### PR TITLE
Remove will-gant as a reviewer

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -299,8 +299,6 @@ areas:
     github: dalvarado
   - name: Katharina Przybill
     github: kathap
-  - name: Will Gant
-    github: will-gant
   - name: Evan Farrar
     github: evanfarrar
   repositories:


### PR DESCRIPTION
This PR removes me as a CAPI reviewer (:slightly_frowning_face:)

My contributions to the project were made SAP, with whom my engagement as a consultant ended on 31 December 2022.

Although I realise my role with the CFF is technically independent of that, I have moved on to a different chapter in my career and unfortunately I lack the time and resources to continue doing this as a volunteer. Best wishes to everyone who continues on the project :-)